### PR TITLE
fixed pto-policy link

### DIFF
--- a/team-empowerment/README.md
+++ b/team-empowerment/README.md
@@ -6,5 +6,5 @@
 2. [Laptop Procurement](laptop-procurement.md)
 3. [Home Office Budget](hardware-budget.md)
 4. [Professional Development Budget](professional-development.md)
-5. [Paid Time Off: Open Vacation Policy](PTO-policy.md)
+5. [Paid Time Off: Open Vacation Policy](pto-policy.md)
 6. [Parental Leave Policy](parental-leave.md)


### PR DESCRIPTION
in the README.md for team empowerment the link to pto-policy was mistyped as PTO-policy making the link not work from the readme.